### PR TITLE
fix: database connection

### DIFF
--- a/charts/hive-metastore/Chart.yaml
+++ b/charts/hive-metastore/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hive-metastore/templates/hive-config.yaml
+++ b/charts/hive-metastore/templates/hive-config.yaml
@@ -38,6 +38,10 @@ data:
           <value>{{- .Values.connections.database.username }}</value>
         </property>
         <property>
+          <name>javax.jdo.option.ConnectionPassword</name>
+          <value>{{- .Values.connections.database.password }}</value>
+        </property>
+        <property>
           <name>datanucleus.autoCreateSchema</name>
           <value>false</value>
         </property>


### PR DESCRIPTION
## Description of the changes  

The **Hive Metastore Helm chart** was failing to establish a connection with the **PostgreSQL database** due to a missing `password` property in the **Hive configuration file** (`charts/hive-metastore/templates/hive-config.yaml`).  

Previously, the Hive Metastore configuration did not include the `javax.jdo.option.ConnectionPassword` property, causing authentication failures when attempting to connect to the database.  

This change ensures that the `password` field is correctly set using the Helm values, allowing the Hive Metastore to authenticate successfully with PostgreSQL.  

This fix addresses this [issue](https://github.com/HEVAWEB/heva-helm-charts/issues/4).  

## Breaking change  

* [x] No  
* [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_  